### PR TITLE
Fix redirect link after reset password

### DIFF
--- a/src/services/Password.tsx
+++ b/src/services/Password.tsx
@@ -6,7 +6,7 @@ export async function RequestResetPassword(
   supabaseClient: SupabaseClient<Database>
 ): Promise<void> {
   const sendResetPasswordEmailResult = await supabaseClient.auth.resetPasswordForEmail(email, {
-    redirectTo: "http://localhost:3000/resetPassword",
+    redirectTo: process.env.NEXT_PUBLIC_DOMAIN_NAME + "/resetPassword",
   });
   if (sendResetPasswordEmailResult.error) {
     throw new Error("Something went wrong!!");


### PR DESCRIPTION
After request resetting password, the link in email still sent user to localhost:3000 not our website.